### PR TITLE
Added third party notice and updated license links

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@ com.unity.virtualmesh © 2025 Unity Technologies
 
 
 
-Licensed under the Unity Companion License for Unity-dependent projects (see unity.com/legal/licenses/unity-companion-license). 
+Licensed under the Unity Companion License for Unity-dependent projects (see [unity.com/legal/licenses/unity-companion-license](https://unity.com/legal/licenses/unity-companion-license)).
 
 
 

--- a/Third Party Notices.md
+++ b/Third Party Notices.md
@@ -1,0 +1,16 @@
+This package contains third-party software components governed by the license(s) indicated below:
+---------
+
+Component Name: "BetterStreamingAssets"
+
+License Type: "MIT"
+
+Copyright (c) 2017 gwiazdorrr
+
+https://github.com/Unity-Technologies/com.unity.virtualmesh/blob/main/Runtime/BetterStreamingAssets/LICENSE.md
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Third Party Notices.md.meta
+++ b/Third Party Notices.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e49d552b7e28fa145b0723b123e286cc
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Purpose of this PR
This PR adds a missing third part license file and fixes a link to the Unity Companion License in the repository's LICENSE.md file.

## Changelog
Added third party notice and updated license links